### PR TITLE
Add filter for leafUserId and provider on Farms and Growers

### DIFF
--- a/docs/field_boundaries_endpoints.md
+++ b/docs/field_boundaries_endpoints.md
@@ -780,7 +780,7 @@ Deletes the field with the given id.
 
 Gets a paged list of all Farms. It is possible to pass some query parameters.
 
-- `providerName`, only matches Farms from this provider (string)
+- `provider`, only matches Farms from this provider (string)
 - `leafUserId`, only matches Farms from this Leaf User (UUID)
 - `page`, an integer specifying the page being fetched
 - `size`, an integer specifying the size of the page (defaults to 20)

--- a/docs/field_boundaries_endpoints.md
+++ b/docs/field_boundaries_endpoints.md
@@ -780,6 +780,8 @@ Deletes the field with the given id.
 
 Gets a paged list of all Farms. It is possible to pass some query parameters.
 
+- `providerName`, only matches Farms from this provider (string)
+- `leafUserId`, only matches Farms from this Leaf User (UUID)
 - `page`, an integer specifying the page being fetched
 - `size`, an integer specifying the size of the page (defaults to 20)
 
@@ -937,6 +939,8 @@ A single Farm as a JSON object.
 Gets a paged list of all Growers. Use the following parameters for paging
 through results.
 
+- `provider`, only matches Growers from this provider (string)
+- `leafUserId`, only matches Growers from this Leaf User (UUID)
 - `page`, an integer specifying the page being fetched
 - `size`, an integer specifying the size of the page (defaults to 20)
 


### PR DESCRIPTION
Add filters by leafUserId and provider on Farms and Growers get all endpoint. Wait for merge this one, we noticed that on farms the provider field was called `providerName`, not `provider`. This has been fixed, but it isn't deployed yet