### PR TITLE
remove sample hyperlink

### DIFF
--- a/docs/operations_sample_output.md
+++ b/docs/operations_sample_output.md
@@ -589,7 +589,6 @@ Select the tab you want to see: "planted", "applied", "harvested", or "tillage".
   \* = Always in response  
   \*\* = Usually in response but not required to pass tests
 
-[Here][sample_summary] you can see a sample summary as response for an operation file
 
 
   </TabItem>
@@ -642,8 +641,6 @@ Select the tab you want to see: "planted", "applied", "harvested", or "tillage".
   \* = Always in response  
   \*\* = Usually in response but not required to pass tests
 
-  [Here][sample_summary] you can see a sample summary as response for an operation file
-
 
 
   </TabItem>
@@ -663,7 +660,6 @@ Select the tab you want to see: "planted", "applied", "harvested", or "tillage".
   \* = Always in response  
   \*\* = Usually in response but not required to pass tests
 
-  [Here][sample_summary] you can see a sample summary as response for an operation file
 
   </TabItem>
   </Tabs>

--- a/docs/operations_sample_output.md
+++ b/docs/operations_sample_output.md
@@ -612,9 +612,6 @@ Select the tab you want to see: "planted", "applied", "harvested", or "tillage".
   \* = Always in response  
   \*\* = Usually in response but not required to pass tests
 
-  [Here][sample_summary] you can see a sample summary as response for an operation file
-
-
   </TabItem>
 
 


### PR DESCRIPTION
It makes more sense without that line of comment, because we are exposing the sample response output for all the operation types above 