### PR TITLE
Add notes about getting data from less than 5 days ago using forecast

### DIFF
--- a/docs/weather_endpoints.md
+++ b/docs/weather_endpoints.md
@@ -377,6 +377,9 @@ will return forecast data for the next seven days by default.
 Get daily historical weather data by Leaf User and field. If the dates are not defined in the endpoint, the response 
 will return data from the last seven days by default.
 
+Please note, historical weather data from less than 5 days ago is unavailable. If you’re wanting historical weather data within the last 5 days, you can use the forecast service to get this information. 
+
+
 | Parameter (to filter by)     | values                                                      |
 |------------------------------|-------------------------------------------------------------|
 | endTime                      | ISO 8601 date. Returns operations until the endTime         |

--- a/docs/weather_overview.md
+++ b/docs/weather_overview.md
@@ -15,7 +15,7 @@ and historical weather variables are available and which data sources are suppor
 
 ## Forecast
 
-Leaf’s weather forecast service provides access to forecasted weather data for up to `10` days. The data can be fetched 
+Leaf’s weather forecast service provides access to forecasted weather data for the past `5` days -  up to `10` days in the future. The data can be fetched 
 daily or hourly.
 
 ### Properties
@@ -51,8 +51,8 @@ The service uses an option to provide the best forecast for any given location w
 
 ## Historical Data
 
-Leaf’s historical weather service provides access to up to `10` years of historical data when available. The data can 
-be fetched daily or hourly.
+Leaf’s historical weather service provides access to up to `5` years of historical data when available. The data can 
+be fetched daily or hourly. Please note, historical weather data from less than 5 days ago is unavailable. If you’re wanting historical weather data within the last 5 days, you can use the forecast service to get this information. 
 
 ### Properties
 


### PR DESCRIPTION
Lacey, Allan P and I have been discussing weather data availability and have added some notes about getting historical data from less than 5 days ago through the forecast service. Also where it states up to 10 years of weather data when it's currently 5 via the data source