### PR TITLE
Fix broken files_sample link on operations endpoints page

### DIFF
--- a/docs/operations_endpoints.md
+++ b/docs/operations_endpoints.md
@@ -44,7 +44,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 [sample_summary]: https://docs.withleaf.io/docs/operations_sample_output#field-operations-summary
 [sample_units]: https://docs.withleaf.io/docs/operations_sample_output#field-operations-units
 [postman]: https://github.com/Leaf-Agriculture/Leaf-API-Postman-Collection
-[files_sample]: https://docs.withleaf.io/docs/machine_file_conversion_sample_output#machine-file-sample]
+[files_sample]: https://docs.withleaf.io/docs/machine_file_conversion_sample_output#machine-file-sample
 
 ## About
 
@@ -1466,7 +1466,7 @@ Allow the user to fetch all files resources that were aggregated to generate an 
 
 #### Response
 
-Check our [sample response](files_sample) to have complete represention on the expected output.
+Check our [sample response][files_sample] to have complete represention on the expected output.
 
 ### Reprocess an operation
 


### PR DESCRIPTION
## Summary
- The "sample response" link under the "Get an operation's files" endpoint response section resolved to `/docs/files_sample`, which returns a 404
- Root cause: the link used inline syntax `(files_sample)` instead of reference link syntax `[files_sample]`, and the reference URL definition had a stray trailing `]`
- Fixed both issues so the link correctly points to `/docs/machine_file_conversion_sample_output#machine-file-sample`

## Test plan
- [x] Verified locally that the operations endpoints page loads
- [x] Confirmed the "sample response" link navigates to the machine file conversion sample output page

Made with [Cursor](https://cursor.com)